### PR TITLE
Fix uninitialized pErrorHandler, memory leaks in lattice destructors, and broken Diamond neighbor indexing.

### DIFF
--- a/src/apothesis.cpp
+++ b/src/apothesis.cpp
@@ -55,6 +55,8 @@ Apothesis::Apothesis(int argc, char *argv[])
     m_iArgc = argc;
     m_vcArgv = argv;
 
+    pErrorHandler = new Utils::ErrorHandler(this);
+
     pParameters = new Utils::Parameters(this);
     pProperties = new Utils::Properties(this);
     pRandomGen = new RandomGen::RandomGenerator( this );

--- a/src/lattice/FCC.cpp
+++ b/src/lattice/FCC.cpp
@@ -30,13 +30,17 @@ void FCC::readSpeciesFromFile() { cout << "Reading file for species is not suppo
 
 void FCC::build()
 {
+    // Free sites previously allocated by buildSites()
+    for (int i = 0; i < m_vSites.size(); i++)
+        delete m_vSites[i];
+
     // The sites of the lattice.
     m_vSites.resize( getSize() );
     for ( int i = 0; i < m_vSites.size(); i++)
         m_vSites[ i ] = new Site();
 
     if ( m_sOrient == "111"){
-        if ( m_iSizeX%2 != 0 || m_iSizeX%2 != 0){
+        if ( m_iSizeX%2 != 0 || m_iSizeY%2 != 0){
             cout << "Error:The size of the lattice must be an even number in each direction." << endl;
             for ( int i = 0; i < m_vSites.size(); i++)
                 delete m_vSites[ i ];

--- a/src/lattice/HCP.cpp
+++ b/src/lattice/HCP.cpp
@@ -106,6 +106,10 @@ void HCP::build()
         m_errorHandler->warningSimple_msg("The lattice initial height is too small.Consider revising.");
     }
 
+    // Free sites previously allocated by buildSites()
+    for (int i = 0; i < m_vSites.size(); i++)
+        delete m_vSites[i];
+
     // The sites of the lattice.
     m_vSites.resize(getSize());
     for (int i = 0; i < m_vSites.size(); i++)

--- a/src/lattice/diamond.cpp
+++ b/src/lattice/diamond.cpp
@@ -22,6 +22,12 @@ Diamond::Diamond(Apothesis *apothesis) : Lattice(apothesis)
     m_Type = Lattice::Diamond;
 }
 
+Diamond::~Diamond()
+{
+    for (int i = 0; i < getSize(); i++)
+        delete m_vSites[i];
+}
+
 void Diamond::setInitialHeight( int height ) { m_iHeight = height; }
 
 void Diamond::readHeightsFromFile() { cout << "Reading file for height is not supported yet for Diamond."; EXIT; }
@@ -29,6 +35,10 @@ void Diamond::readHeightsFromFile() { cout << "Reading file for height is not su
 void Diamond::readSpeciesFromFile() { cout << "Reading file for species is not supported yet for Diamond."; EXIT; }
 
 void Diamond::build(){
+    // Free sites previously allocated by buildSites()
+    for (int i = 0; i < m_vSites.size(); i++)
+        delete m_vSites[i];
+
     // The sites of the lattice.
     m_vSites.resize(getSize());
     for (int i = 0; i < m_vSites.size(); i++)
@@ -61,19 +71,14 @@ void Diamond::writeXYZ(string){}
 
 void Diamond::mf_neigh() {
 
-    // The sites of the lattice.
-    m_vSites.resize(getSize());
-
-    int L = getSize();
-
     for (int site = 0; site < getSize(); site++) {
-        int x = site / L;
-        int y = site % L;
+        int x = site / m_iSizeY;
+        int y = site % m_iSizeY;
 
-        m_vSites[ site ]->setNeigh( m_vSites[ ((x + 1) % L) * L + y ]); //Right
-        m_vSites[ site ]->setNeigh( m_vSites[ x * L + ((y + 1) % L) ]); //Down
-        m_vSites[ site ]->setNeigh( m_vSites[ ((x - 1 + L) % L) * L + y ]); //Left
-        m_vSites[ site ]->setNeigh( m_vSites[ x * L + ((y - 1 + L) % L) ]); //Up
+        m_vSites[ site ]->setNeigh( m_vSites[ ((x + 1) % m_iSizeX) * m_iSizeY + y ]); //Down
+        m_vSites[ site ]->setNeigh( m_vSites[ x * m_iSizeY + ((y + 1) % m_iSizeY) ]); //Right
+        m_vSites[ site ]->setNeigh( m_vSites[ ((x - 1 + m_iSizeX) % m_iSizeX) * m_iSizeY + y ]); //Up
+        m_vSites[ site ]->setNeigh( m_vSites[ x * m_iSizeY + ((y - 1 + m_iSizeY) % m_iSizeY) ]); //Left
     }
 }
 

--- a/src/lattice/diamond.h
+++ b/src/lattice/diamond.h
@@ -39,7 +39,7 @@ public:
     Diamond( Apothesis* apothesis );
 
     /// Distructor.
-    virtual ~Diamond(){}
+    virtual ~Diamond();
 
     /// Build the lattice with an intitial height.
     void build();


### PR DESCRIPTION

- pErrorHandler was being set to null in the constructor but never actually allocated.  There are 20+ call sites across IO, lattice and process classes that dereference it any error path would segfault.

- Also noticed Diamond's destructor was completely empty while SimpleCubic, FCC and HCP all clean up their sites properly. Added the same pattern.

- FCC, HCP and Diamond had a double-allocation bug - build() was creating fresh sites but buildSites() had already allocated them. The first batch just leaked silently.

- Small one: FCC 111 was checking m_iSizeX twice in the validation condition instead of checking both X and Y. The error message even says "each direction" so it's clearly a copy-paste slip.

- Diamond mf_neigh() used getSize() (the total X*Y count) as the row stride for 2D indexing. That makes x always 0 and the neighbor indices go straight out of bounds. Fixed to use m_iSizeX and m_iSizeY properly.