### PR TITLE
fix: correct diffusion Arrhenius formula and RMS roughness calculation

### DIFF
--- a/src/processes/diffusion_types.cpp
+++ b/src/processes/diffusion_types.cpp
@@ -40,7 +40,7 @@ double arrheniusType(Diffusion* proc)
     double k = proc->getParameters()->dkBoltz;
     E = E/proc->getParameters()->dAvogadroNum;
     Em = Em/proc->getParameters()->dAvogadroNum;
-    double A = exp(E-Em)/(k*T);
+    double A = exp((E-Em)/(k*T));
 
     return v0*A*exp(-(double)n*E/(k*T));
 }

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -30,8 +30,10 @@ double Properties::getRMS()
 
     mean = sum/(double)m_lattice->getSize();
 
-    for (unsigned int i=0; i<m_lattice->getSize(); i++)
-        dev += m_lattice->getSite( i )->getHeight()*m_lattice->getSite( i )->getHeight();
+    for (unsigned int i=0; i<m_lattice->getSize(); i++){
+        double diff = m_lattice->getSite( i )->getHeight() - mean;
+        dev += diff*diff;
+    }
 
     return sqrt( dev/(double)m_lattice->getSize() );
 }


### PR DESCRIPTION
Found two math bugs while reading through the physics layer.

**1. diffusion_types.cpp**
```cpp
// before
double A = exp(E-Em)/(k*T);
// after
double A = exp((E-Em)/(k*T));
```

The `kT` division needs to be inside the exponent as written it overflows for any real energy value. The correct form is in Lam & Vlachos (2001) Phys. Rev. B 64, 035401, which is actually cited in the comment right above this line.

**2. properties.cpp**
```cpp
// before
dev += h * h;
// after
double diff = h - mean;
dev += diff * diff;
```

`mean` was computed but never used in the deviation loop, so getRMS() was returning sqrt(mean(h²)) instead of actual surface roughness. RMS output was wrong for every run.

Both one-liners, build clean.