### PR TITLE
#21 Fix Windows build issues: toolchain setup, CMake compatibility, and C++17 requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,18 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 #set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if (WIN32 AND NOT CMAKE_GENERATOR MATCHES "MinGW")
+    message(WARNING "On Windows, consider using MinGW or MSYS2 for building.")
+endif()
 
 project(apothesis)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
 
 set(header_files
     ./src/apothesis.h

--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ From `src/input.kmc` copy the `input.kmc` file and put it inside the build folde
 
 ```
 
+## Build on Windows (MSYS2 + MinGW)
+
+1. Install MSYS2
+2. Install dependencies:
+   ```pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake```
+
+3. Open "MSYS2 MinGW64" terminal
+
+4. Build:
+   ```
+   mkdir build
+   cd build
+   cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=17 ..
+   mingw32-make
+   ```
+
 Contact information:
 Nikolaos (Nikos) Cheimarios: 
 nixeimar@chemeng.ntua.gr

--- a/src/processes/process.h
+++ b/src/processes/process.h
@@ -21,7 +21,11 @@
 #include <iostream>
 #include <string>
 #include <map>
-#include <any>
+#if __cplusplus >= 201703L
+    #include <any>
+#else
+    #error "C++17 or higher is required (std::any not supported)"
+#endif
 #include "lattice.h"
 #include "site.h"
 #include "extLibs/random_generator.h"


### PR DESCRIPTION
## Summary

This PR addresses multiple issues encountered while building Apothesis on Windows using MSYS2/MinGW. The current build instructions are incomplete for Windows environments and lead to configuration and compilation failures.

## Issues Identified

1. CMake Compatibility Issue
   - The project uses an older `cmake_minimum_required` version, which causes errors with newer CMake versions.

2. Missing Toolchain Specification
   - CMake defaults to `NMake Makefiles` on Windows, which requires MSVC.
   - This leads to errors such as:
     - `nmake not found`
     - `CMAKE_CXX_COMPILER not set`

3. Compiler Version Issue
   - The project uses `<any>` (C++17 feature), but older compilers (e.g., GCC 6.3) do not support it.
   - This results in:
     - `fatal error: any: No such file or directory`


Fix Windows build issues and modernize CMake configuration

- Updated cmake_minimum_required to 3.10
- Enforced C++17 standard (required for std::any)
- Added compiler warnings for GCC/Clang
- Improved error handling for unsupported compilers
- Added guidance for Windows (MinGW/MSYS2) builds