### PR TITLE
fix: partially resolve compiler warnings (issue #5)

### DIFF
--- a/src/IO/io.cpp
+++ b/src/IO/io.cpp
@@ -21,15 +21,15 @@ IO::IO(Apothesis* apothesis):Pointers(apothesis),
     m_sLatticeType("NONE"),
     m_sProcess("process"),
     m_sLattice("lattice"),
+    m_sSteps("steps"),
     m_sTemperature("temperature"),
     m_sPressure("pressure"),
+    m_sCommentLine("#"),
     m_sTime("time_duration"),
-    m_sSteps("steps"),
     m_sRandom("random"),
     m_sSpecies("species"),
     m_sWrite("write"),
     m_sGrowth("growth"),
-    m_sCommentLine("#"),
     m_sPrecursors("precursors"),
     m_sReport("report"),
     m_sHeights("heights.txt"),
@@ -467,10 +467,8 @@ string IO::simplified( string str )
     bool is_white = false;
     bool was_white = false;
     bool append = false;
-    size_t i = 0;
     size_t n = str.size();
     size_t nm = n - 1;
-    string::iterator it = str.begin();
 
     for (size_t i = 0; i < n; i++) {
         c = str[i];
@@ -497,9 +495,7 @@ string IO::simplified( string str )
 
 bool IO::isNumber( string str){
     char c;
-    size_t i = 0;
     size_t n = str.size();
-    string::iterator it = str.begin();
 
     bool bPlusFound = false;
     bool bPlusFound2 = false;

--- a/src/IO/reader.h
+++ b/src/IO/reader.h
@@ -36,16 +36,16 @@ public:
     Reader();
     explicit Reader(Apothesis *apothesis): Pointers(apothesis),
         m_sBuildKey("build_lattice"),
-        m_sReadKey("read_lattice"),
-        m_sLatticeKey("lattice_species"),
         m_sStepKey("steps"),
+        m_sLatticeKey("lattice_species"),
+        m_sReadKey("read_lattice"),
         m_sNSpeciesKey("nspecies"),
         m_sNProcKey("nprocesses"),
-        m_sPressureKey("pressure"),
         m_sTemperatureKey("temperature"),
+        m_sPressureKey("pressure"),
         m_sTimeKey("time"),
-        m_sReactionKey("reaction"),
         m_sSiteKey("*"),
+        m_sReactionKey("reaction"),
         m_sCommentLine("#")
     {
         //Initialize the map for the lattice

--- a/src/apothesis.cpp
+++ b/src/apothesis.cpp
@@ -45,12 +45,12 @@ using namespace MicroProcesses;
 //using namespace Utils;
 
 Apothesis::Apothesis(int argc, char *argv[])
-    : pLattice(0),
+    : pReader(0),
+      pLattice(0),
       pErrorHandler(0),
-      pReader(0),
+      m_debugMode(false),
       m_dRTot(0.0),
-      m_dProcRate(0.0),
-      m_debugMode(false)
+      m_dProcRate(0.0)
 {
     m_iArgc = argc;
     m_vcArgv = argv;
@@ -455,7 +455,6 @@ void Apothesis::exec()
     //    pLattice->writeXYZ( "initial.xzy" );
 
     // The average height for the first time
-    double timeGrowth = 0;
     double meanDHPrevStep = pProperties->getMeanDH();
     double prevTimeStep = 0.0;
 
@@ -505,8 +504,6 @@ void Apothesis::exec()
                 Site* s = *next( p.second.begin(), m_iSiteNum );
 
                 //Compute the average height before performing the process to measure the growth rate
-                timeGrowth = m_dProcTime;
-
                 p.first->perform( s );
 
                 //Count the event for this class

--- a/src/lattice/FCC.cpp
+++ b/src/lattice/FCC.cpp
@@ -1158,7 +1158,6 @@ void FCC::writeXYZ( string filename )
 
 void FCC::check()
 {
-    int k = 0;
 
     cout << "Checking lattice..." << endl;
 

--- a/src/lattice/site.cpp
+++ b/src/lattice/site.cpp
@@ -23,8 +23,7 @@
 namespace SurfaceTiles
 {
 
-Site::Site():m_phantom(false),m_isLowerStep(false), m_isHigherStep(false), m_bIsOccupied(false)
-  {
+Site::Site():m_phantom(false),m_isLowerStep(false), m_bIsOccupied(false), m_isHigherStep(false)  {
       vector<Site* > vec;
       m_m1stNeighs = { {-1, vec}, { 0, vec }, {1, vec }, };
   }

--- a/src/processes/process.cpp
+++ b/src/processes/process.cpp
@@ -17,7 +17,7 @@
 
 #include "process.h"
 
-Process::Process():m_iHappened(0),m_bUncoAccept(false), m_iNumSites(1),  m_iNumNeighs(1), m_iNumVacant(1) {}
+Process::Process():m_bUncoAccept(false),m_iHappened(0), m_iNumSites(1),  m_iNumNeighs(1), m_iNumVacant(1) {}
 Process::~Process(){}
 
 bool Process::isPartOfGrowth( string name ){


### PR DESCRIPTION
## Summary
Fixes compiler warnings reported in Issue #5 .


## Changes
- Fix `-Wreorder` in `src/apothesis.cpp` — reordered initializer 
  list to match header declaration order
- Fix `-Wreorder` in `src/lattice/site.cpp`
- Fix `-Wreorder` in `src/processes/process.cpp`
- Fix `-Wreorder` in `src/IO/reader.h`
- Fix `-Wreorder` in `src/IO/io.cpp`
- Remove unused variable `timeGrowth` in `src/apothesis.cpp`
- Remove unused variable `k` in `src/lattice/FCC.cpp`
- Remove unused variable declarations in `src/IO/io.cpp`

## Remaining
`-Wsign-compare` and `-Wunused-parameter` warnings will be 
addressed in follow-up commits.

Fixes #5